### PR TITLE
Fix incorrect behavior when passing command argument with space(s).

### DIFF
--- a/src/main/groovy/repo/build/ExecuteProcess.groovy
+++ b/src/main/groovy/repo/build/ExecuteProcess.groovy
@@ -2,7 +2,6 @@ package repo.build
 
 import groovy.transform.CompileStatic
 import org.apache.log4j.Logger
-import org.fusesource.jansi.AnsiOutputStream
 
 @CompileStatic
 class ExecuteProcess {
@@ -10,62 +9,13 @@ class ExecuteProcess {
     static Object outSync = new Object();
     public static final String ACTION_EXECUTE_CMD0 = 'executeProcessExecuteCmd0'
 
-    static String executeCmd0(File dir, String cmd) {
-        return executeCmd0(dir, cmd, true)
-    }
-
-    static String executeCmd0(File dir, String cmd, boolean checkErrorCode) {
-        executeCmd0(dir, cmd.split(' '), checkErrorCode)
-    }
-
-    static String executeCmd0(File dir, String[] args, boolean checkErrorCode) {
-        String cmd = args.join(' ')
-        logger.debug("execute '$cmd' in '$dir'")
-
-        ProcessBuilder builder = new ProcessBuilder()
-                .command(args)
-                .redirectErrorStream(true)
-                .directory(dir)
-
-        Process process = builder.start()
-
-        final StringWriter writer = new StringWriter()
-        final ByteArrayOutputStream bufferStream = new ByteArrayOutputStream(10000);
-
-        process.consumeProcessOutput(new OutputStream() {
-            @Override
-            void write(int b) throws IOException {
-                writer.write(b)
-                bufferStream.write(b)
-            }
-        }, System.err)
-
-        def exitValue = process.waitFor()
-        // for read process output
-        Thread.sleep(100)
-
-        def outStream = new AnsiOutputStream(System.out)
-        if (bufferStream.size() > 0) {
-            synchronized (outSync) {
-                for (int b : bufferStream.toByteArray()) {
-                    outStream.write(b);
-                }
-            }
-        }
-
-        if (checkErrorCode && exitValue != 0) {
-            throw new RepoBuildException("name '$cmd' has exit code $exitValue");
-        }
-        return writer.buffer.toString()
-    }
-
-    static String executeCmd0(ActionContext parentContext, File dir, String cmd, boolean checkErrorCode) {
+    static String executeCmd0(ActionContext parentContext, File dir, String[] cmd, boolean checkErrorCode) {
         def context = parentContext.newChild(ACTION_EXECUTE_CMD0)
         context.withCloseable {
             logger.debug("execute '$cmd' in '$dir'")
 
             ProcessBuilder builder = new ProcessBuilder()
-                    .command(cmd.split(' '))
+                    .command(cmd)
                     .redirectErrorStream(true)
                     .directory(dir)
 
@@ -92,4 +42,7 @@ class ExecuteProcess {
         }
     }
 
+    static String executeCmd0(ActionContext parentContext, File dir, String cmd, boolean checkErrorCode) {
+        return executeCmd0(parentContext, dir, cmd.split(' '), checkErrorCode);
+    }
 }

--- a/src/main/groovy/repo/build/Git.groovy
+++ b/src/main/groovy/repo/build/Git.groovy
@@ -103,10 +103,10 @@ class Git {
     static void user(ActionContext parentContext, File dir, String userName, String userEmail) {
         def context = parentContext.newChild(ACTION_USER)
         context.withCloseable {
-            //ExecuteProcess.executeCmd0(context, dir, 'git config --local --remove-section user', false)
+            ExecuteProcess.executeCmd0(context, dir, 'git config --local --remove-section user', false)
             if (userName?.trim() && userEmail?.trim()) {
-                ExecuteProcess.executeCmd0(context, dir, "git config --local user.name $userName", true)
-                ExecuteProcess.executeCmd0(context, dir, "git config --local user.email $userEmail", true)
+                ExecuteProcess.executeCmd0(context, dir, ['git', 'config', '--local', 'user.name', userName] as String[], true);
+                ExecuteProcess.executeCmd0(context, dir, ['git', 'config', '--local', 'user.email', userEmail] as String[], true);
             }
         }
     }


### PR DESCRIPTION
1) ExecuteProcess.executeCmd0 splits given command line by space and
that's not correct when a parameter itself contains spaces.
E.g. `git config user.name John Doe` actually adds
'user.name = John' to .git/config.

2) Git.user() should remove the entire `user` section before configuring
user name & E-mail. Otherwise each call creates a new user row in
.git/config (probably a git bug).